### PR TITLE
Add custom_gpt_orchestrator function and test scripts

### DIFF
--- a/backend/custom_gpt_orchestrator/__init__.py
+++ b/backend/custom_gpt_orchestrator/__init__.py
@@ -1,0 +1,208 @@
+import json
+import logging
+import re
+import time
+from typing import Any, Dict, List
+
+import azure.functions as func
+import requests
+
+from proxy_router import ACTION_MAP
+
+ALLOWED_TOOLS = set(ACTION_MAP.keys())
+PLACEHOLDER_PATTERN = re.compile(r"^\$prev\[(\d+)\](.*)$")
+PATH_TOKEN_PATTERN = re.compile(r"(\.[A-Za-z0-9_\-]+|\[\d+\])")
+
+
+def _make_response(body: Any, status_code: int = 200) -> func.HttpResponse:
+    if isinstance(body, (dict, list)):
+        payload = json.dumps(body, ensure_ascii=False)
+    else:
+        payload = str(body)
+    return func.HttpResponse(payload, status_code=status_code, mimetype="application/json")
+
+
+def _extract_user_id(req: func.HttpRequest, data: Dict[str, Any]) -> str:
+    user_id = (
+        req.headers.get("x-user-id")
+        or req.params.get("user_id")
+        or (data or {}).get("user_id")
+        or "default"
+    )
+    return str(user_id).strip() or "default"
+
+
+def _resolve_path(value: Any, path: str) -> Any:
+    if not path:
+        return value
+    tokens = PATH_TOKEN_PATTERN.findall(path)
+    if "".join(tokens) != path:
+        raise ValueError(f"Invalid placeholder path: {path}")
+    current = value
+    for token in tokens:
+        if token.startswith("."):
+            key = token[1:]
+            if not isinstance(current, dict) or key not in current:
+                raise ValueError(f"Missing key '{key}' in placeholder path")
+            current = current[key]
+        elif token.startswith("["):
+            index = int(token[1:-1])
+            if not isinstance(current, list) or index >= len(current):
+                raise ValueError(f"Index {index} out of range in placeholder path")
+            current = current[index]
+    return current
+
+
+def _resolve_placeholders(value: Any, previous_results: List[Any]) -> Any:
+    if isinstance(value, str):
+        match = PLACEHOLDER_PATTERN.match(value)
+        if not match:
+            return value
+        index = int(match.group(1))
+        if index >= len(previous_results):
+            raise ValueError(f"Placeholder index {index} out of range")
+        path = match.group(2) or ""
+        return _resolve_path(previous_results[index], path)
+    if isinstance(value, list):
+        return [_resolve_placeholders(item, previous_results) for item in value]
+    if isinstance(value, dict):
+        return {key: _resolve_placeholders(val, previous_results) for key, val in value.items()}
+    return value
+
+
+def _normalize_tool_chain(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    tool_chain = data.get("tool_chain")
+    if tool_chain is None:
+        tool = data.get("tool")
+        params = data.get("params", {})
+        if tool is None:
+            raise ValueError("Provide either tool_chain or tool")
+        tool_chain = [{"tool": tool, "params": params}]
+    elif data.get("tool") is not None:
+        raise ValueError("Provide tool_chain or tool, not both")
+    if not isinstance(tool_chain, list) or not tool_chain:
+        raise ValueError("tool_chain must be a non-empty list")
+    return tool_chain
+
+
+def _validate_chain(tool_chain: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    for idx, step in enumerate(tool_chain):
+        if not isinstance(step, dict):
+            raise ValueError(f"tool_chain[{idx}] must be an object")
+        tool = step.get("tool")
+        if not isinstance(tool, str) or not tool:
+            raise ValueError(f"tool_chain[{idx}].tool must be a non-empty string")
+        if ALLOWED_TOOLS and tool not in ALLOWED_TOOLS:
+            raise ValueError(f"Unsupported tool '{tool}' in tool_chain")
+        params = step.get("params", {})
+        if params is None:
+            step["params"] = {}
+        elif not isinstance(params, dict):
+            raise ValueError(f"tool_chain[{idx}].params must be an object")
+    return tool_chain
+
+
+def _call_direct(action: str, params: Dict[str, Any], user_id: str) -> Dict[str, Any]:
+    if action not in ACTION_MAP:
+        raise RuntimeError(f"Unsupported action '{action}' for direct dispatch")
+    endpoint = ACTION_MAP[action]
+    url = endpoint["url"]
+    code = endpoint["code"]
+    headers = {"X-User-Id": user_id}
+    if endpoint["method"] == "GET":
+        query = {**params}
+        if code:
+            query["code"] = code
+        response = requests.get(url, params=query, headers=headers, timeout=45)
+    elif endpoint["method"] == "POST":
+        full_url = f"{url}?code={code}" if code else url
+        response = requests.post(full_url, json=params, headers=headers, timeout=45)
+    else:
+        raise RuntimeError(f"Unsupported method {endpoint['method']} for action {action}")
+    try:
+        body = response.json()
+    except ValueError:
+        body = {"raw_response": response.text}
+    return {
+        "status_code": response.status_code,
+        "body": body,
+    }
+
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    logging.info("custom_gpt_orchestrator triggered")
+    try:
+        data = req.get_json()
+    except ValueError:
+        return _make_response({"error": "Invalid JSON payload"}, status_code=400)
+
+    user_id = _extract_user_id(req, data)
+    try:
+        tool_chain = _normalize_tool_chain(data)
+        tool_chain = _validate_chain(tool_chain)
+    except ValueError as exc:
+        return _make_response({"error": str(exc), "user_id": user_id}, status_code=400)
+
+    trace: List[Dict[str, Any]] = []
+    previous_results: List[Any] = []
+
+    for index, step in enumerate(tool_chain):
+        tool = step["tool"]
+        try:
+            resolved_params = _resolve_placeholders(step.get("params", {}), previous_results)
+        except ValueError as exc:
+            return _make_response({
+                "error": str(exc),
+                "user_id": user_id,
+                "trace": trace,
+            }, status_code=400)
+
+        params_with_user = {**resolved_params, "user_id": user_id}
+        start_time = time.time()
+        try:
+            result = _call_direct(tool, params_with_user, user_id)
+        except Exception as exc:
+            trace.append({
+                "step": index,
+                "tool": tool,
+                "params": resolved_params,
+                "status": "failed",
+                "error": str(exc),
+                "duration_ms": (time.time() - start_time) * 1000,
+            })
+            return _make_response({
+                "status": "failed",
+                "user_id": user_id,
+                "error": str(exc),
+                "trace": trace,
+            }, status_code=500)
+
+        duration_ms = (time.time() - start_time) * 1000
+        step_entry = {
+            "step": index,
+            "tool": tool,
+            "params": resolved_params,
+            "status_code": result["status_code"],
+            "duration_ms": duration_ms,
+            "response": result["body"],
+        }
+        trace.append(step_entry)
+
+        if result["status_code"] >= 400:
+            return _make_response({
+                "status": "failed",
+                "user_id": user_id,
+                "error": "Downstream tool call failed",
+                "downstream_response": result["body"],
+                "trace": trace,
+            }, status_code=result["status_code"])
+
+        previous_results.append(result["body"])
+
+    final_result = previous_results[-1] if previous_results else None
+    return _make_response({
+        "status": "success",
+        "user_id": user_id,
+        "result": final_result,
+        "trace": trace,
+    })

--- a/backend/custom_gpt_orchestrator/function.json
+++ b/backend/custom_gpt_orchestrator/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["post"],
+      "route": "custom_gpt_orchestrator"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/backend/custom_gpt_orchestrator/test_custom_gpt_orchestrator.sh
+++ b/backend/custom_gpt_orchestrator/test_custom_gpt_orchestrator.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:7071}"
+ENDPOINT="/api/custom_gpt_orchestrator"
+USER_ID="${USER_ID:-default}"
+
+if [[ -n "${FUNCTION_CODE_CUSTOM_GPT_ORCHESTRATOR:-}" ]]; then
+  URL="${BASE_URL}${ENDPOINT}?code=${FUNCTION_CODE_CUSTOM_GPT_ORCHESTRATOR}"
+else
+  URL="${BASE_URL}${ENDPOINT}"
+fi
+
+payload=$(python - <<'PY'
+import json
+
+payload = {
+    "tool_chain": [
+        {"tool": "list_blobs", "params": {"prefix": ""}},
+        {"tool": "read_blob_file", "params": {"file_name": "$prev[0].blobs[0]"}},
+    ]
+}
+print(json.dumps(payload))
+PY
+)
+
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-User-Id: ${USER_ID}" \
+  -d "${payload}" \
+  "${URL}" | python -m json.tool

--- a/backend/custom_gpt_orchestrator/test_custom_gpt_orchestrator_each_tool.sh
+++ b/backend/custom_gpt_orchestrator/test_custom_gpt_orchestrator_each_tool.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:7071}"
+ENDPOINT="/api/custom_gpt_orchestrator"
+USER_ID="${USER_ID:-default}"
+
+if [[ -n "${FUNCTION_CODE_CUSTOM_GPT_ORCHESTRATOR:-}" ]]; then
+  URL="${BASE_URL}${ENDPOINT}?code=${FUNCTION_CODE_CUSTOM_GPT_ORCHESTRATOR}"
+else
+  URL="${BASE_URL}${ENDPOINT}"
+fi
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required env var: ${name}" >&2
+    exit 1
+  fi
+}
+
+call_tool() {
+  local tool="$1"
+  local params_json="$2"
+  echo "Calling tool: ${tool}"
+  curl -sS -X POST \
+    -H "Content-Type: application/json" \
+    -H "X-User-Id: ${USER_ID}" \
+    -d "{\"tool\":\"${tool}\",\"params\":${params_json}}" \
+    "${URL}" | python -m json.tool
+}
+
+call_tool "get_current_time" "{}"
+
+require_env "TARGET_BLOB_NAME"
+require_env "NEW_ENTRY_JSON"
+call_tool "add_new_data" "{\"target_blob_name\":\"${TARGET_BLOB_NAME}\",\"new_entry\":${NEW_ENTRY_JSON}}"
+
+require_env "TARGET_BLOB_NAME"
+call_tool "get_filtered_data" "{\"target_blob_name\":\"${TARGET_BLOB_NAME}\"}"
+
+require_env "MANAGE_OPERATION"
+call_tool "manage_files" "{\"operation\":\"${MANAGE_OPERATION}\"}"
+
+require_env "TARGET_BLOB_NAME"
+require_env "FIND_KEY"
+require_env "FIND_VALUE"
+require_env "UPDATE_KEY"
+require_env "UPDATE_VALUE"
+call_tool "update_data_entry" "{\"target_blob_name\":\"${TARGET_BLOB_NAME}\",\"find_key\":\"${FIND_KEY}\",\"find_value\":\"${FIND_VALUE}\",\"update_key\":\"${UPDATE_KEY}\",\"update_value\":\"${UPDATE_VALUE}\"}"
+
+require_env "TARGET_BLOB_NAME"
+require_env "KEY_TO_FIND"
+require_env "VALUE_TO_FIND"
+call_tool "remove_data_entry" "{\"target_blob_name\":\"${TARGET_BLOB_NAME}\",\"key_to_find\":\"${KEY_TO_FIND}\",\"value_to_find\":\"${VALUE_TO_FIND}\"}"
+
+require_env "TARGET_BLOB_NAME"
+require_env "FILE_CONTENT"
+call_tool "upload_data_or_file" "{\"target_blob_name\":\"${TARGET_BLOB_NAME}\",\"file_content\":\"${FILE_CONTENT}\"}"
+
+call_tool "list_blobs" "{}"
+
+require_env "READ_BLOB_FILE_NAME"
+call_tool "read_blob_file" "{\"file_name\":\"${READ_BLOB_FILE_NAME}\"}"
+
+require_env "USER_MESSAGE"
+require_env "ASSISTANT_RESPONSE"
+call_tool "save_interaction" "{\"user_message\":\"${USER_MESSAGE}\",\"assistant_response\":\"${ASSISTANT_RESPONSE}\"}"
+
+call_tool "get_interaction_history" "{}"

--- a/backend/custom_gpt_orchestrator/test_custom_gpt_orchestrator_tool_chain.sh
+++ b/backend/custom_gpt_orchestrator/test_custom_gpt_orchestrator_tool_chain.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:7071}"
+ENDPOINT="/api/custom_gpt_orchestrator"
+USER_ID="${USER_ID:-default}"
+
+if [[ -n "${FUNCTION_CODE_CUSTOM_GPT_ORCHESTRATOR:-}" ]]; then
+  URL="${BASE_URL}${ENDPOINT}?code=${FUNCTION_CODE_CUSTOM_GPT_ORCHESTRATOR}"
+else
+  URL="${BASE_URL}${ENDPOINT}"
+fi
+
+payload_two=$(python - <<'PY'
+import json
+
+payload = {
+    "tool_chain": [
+        {"tool": "list_blobs", "params": {}},
+        {"tool": "read_blob_file", "params": {"file_name": "$prev[0].blobs[0]"}},
+    ]
+}
+print(json.dumps(payload))
+PY
+)
+
+echo "Calling tool_chain (2 steps)"
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-User-Id: ${USER_ID}" \
+  -d "${payload_two}" \
+  "${URL}" | python -m json.tool
+
+payload_three=$(python - <<'PY'
+import json
+
+payload = {
+    "tool_chain": [
+        {"tool": "list_blobs", "params": {}},
+        {"tool": "read_blob_file", "params": {"file_name": "$prev[0].blobs[0]"}},
+        {"tool": "save_interaction", "params": {"user_message": "Loaded file", "assistant_response": "$prev[1]"}},
+    ]
+}
+print(json.dumps(payload))
+PY
+)
+
+echo "Calling tool_chain (3 steps)"
+curl -sS -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-User-Id: ${USER_ID}" \
+  -d "${payload_three}" \
+  "${URL}" | python -m json.tool

--- a/backend/custom_gpt_orchestrator/test_custom_gpt_orchestrator_wrong_params.sh
+++ b/backend/custom_gpt_orchestrator/test_custom_gpt_orchestrator_wrong_params.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:7071}"
+ENDPOINT="/api/custom_gpt_orchestrator"
+USER_ID="${USER_ID:-default}"
+
+if [[ -n "${FUNCTION_CODE_CUSTOM_GPT_ORCHESTRATOR:-}" ]]; then
+  URL="${BASE_URL}${ENDPOINT}?code=${FUNCTION_CODE_CUSTOM_GPT_ORCHESTRATOR}"
+else
+  URL="${BASE_URL}${ENDPOINT}"
+fi
+
+payload=$(python - <<'PY'
+import json
+
+payload = {
+    "tool": "get_filtered_data",
+    "params": {}
+}
+print(json.dumps(payload))
+PY
+)
+
+echo "Calling tool with missing params (expect failure)"
+status=$(curl -sS -o /tmp/custom_gpt_orchestrator_wrong_params.json -w "%{http_code}" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-User-Id: ${USER_ID}" \
+  -d "${payload}" \
+  "${URL}")
+
+cat /tmp/custom_gpt_orchestrator_wrong_params.json | python -m json.tool
+
+if [[ "${status}" -lt 400 ]]; then
+  echo "Expected failure but got status ${status}" >&2
+  exit 1
+fi
+
+echo "Received expected failure status ${status}"


### PR DESCRIPTION
### Motivation
- Provide an HTTP-triggered Azure Function that can orchestrate multi-step tool calls with placeholder resolution and tracing.
- Centralize direct dispatch to mapped backend actions via `ACTION_MAP` and normalize/validate incoming `tool_chain` payloads.
- Add automated test scripts to exercise each tool, validate 2- and 3-step chains with placeholders, and verify error handling for missing parameters.

### Description
- Add `backend/custom_gpt_orchestrator/__init__.py` implementing the orchestrator with `_normalize_tool_chain`, `_validate_chain`, `_resolve_placeholders`, `_call_direct`, and `main` to perform per-step tracing and downstream dispatch.
- Add `backend/custom_gpt_orchestrator/function.json` to register the HTTP trigger route `custom_gpt_orchestrator` for the Azure Function.
- Add three executable test scripts: `test_custom_gpt_orchestrator_each_tool.sh`, `test_custom_gpt_orchestrator_tool_chain.sh`, and `test_custom_gpt_orchestrator_wrong_params.sh` that call the function with single-tool requests, 2/3-step tool chains using `$prev` placeholders, and a negative missing-params case respectively.
- Make the test scripts executable (`chmod +x`) and include environment checks for required variables used by the scripts.

### Testing
- Marked the test scripts executable (`chmod +x`) and committed the new files, which succeeded.
- Ran `backend/custom_gpt_orchestrator/test_custom_gpt_orchestrator_each_tool.sh`, which attempted to call the local Functions host and failed because `curl` could not connect to `localhost:7071` (stopped on first failure per instructions).
- No further automated test scripts were executed after the first failure, so `test_custom_gpt_orchestrator_tool_chain.sh` and `test_custom_gpt_orchestrator_wrong_params.sh` were not run.
- Recommendation: run the added scripts against a running Functions host with `ACTION_MAP` configured and required environment variables set to validate end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d2d63485c83219f88a07efd568c71)