### PR TITLE
Add PA stage/phase routing to Responses runtime

### DIFF
--- a/PLANNING_SUMMARY.md
+++ b/PLANNING_SUMMARY.md
@@ -354,3 +354,86 @@ backend/shared/
 **Status**: 🟡 Planning Complete - Ready for Implementation Approval
 
 **Recommendation**: Review IMPLEMENTATION_PLAN_UPDATED.md and approve to begin Phase 1.
+
+---
+
+## 🧭 PA Semantic Prompting v1 (Stage/Phase) — Updated Plan
+
+### Goal
+Introduce semantic control for the Personal Assistant by passing `stage` and `phase` into the OpenAI Responses API (dashboard prompt variables), mirroring the CV-generator pattern.
+
+### Recommended Stages (PA intents)
+**Core**
+- CALENDAR_QUERY
+- CALENDAR_WRITE
+- EMAIL_QUERY
+- EMAIL_WRITE
+- TASKS_MANAGE
+- DAILY_PLAN
+- NOTES_KB
+- DECISION_SUPPORT
+
+**Pro/Work**
+- DOC_ANALYSIS
+- REPORTING
+- TRAVEL_PLANNING
+
+**Optional (future)**
+- CONTACTS_MANAGE
+- FILES_MANAGE
+- MEETING_SUMMARY
+
+### Recommended Phases (action gate)
+- DISCOVERY: clarify intent + missing data
+- PLAN: draft actions, no external mutations
+- CONFIRM: show exact actions, request approval
+- EXECUTE: run tools/mutations/sends
+- REPORT: results + optional trace/save
+
+---
+
+### Iteration 1 — Foundation (no architecture refactor)
+1) **Responses API payload**
+   - Add `prompt.variables = { stage, phase }`.
+2) **Inline Intent Router**
+   - Lightweight classifier returning top-k intents, `recommended_stage`, `recommended_phase`, `need_clarification`, and `clarify_questions`.
+3) **Logging**
+   - Log stage/phase in traces.
+
+**DoD**
+- Request includes variables.
+- Stage/phase visible in logs.
+- Dashboard prompt reacts to stage/phase (manual smoke test).
+
+### Iteration 2 — Gating & Safety
+1) Enforce PLAN → CONFIRM → EXECUTE for `*_WRITE`.
+2) Add “what will happen” summary in CONFIRM.
+3) Deny list of mutating actions in PLAN/CONFIRM.
+
+**DoD**
+- No mutating tools in PLAN/CONFIRM.
+- EMAIL_WRITE / CALENDAR_WRITE never execute without CONFIRM.
+
+### Iteration 3 — Logging for ML (WP6)
+1) Log: user_text, top_intents + p, final stage/phase, confirmation flag.
+2) Export JSONL dataset to storage.
+
+**DoD**
+- Dataset grows automatically.
+- Ready for future intent model training.
+
+---
+
+### Test Plan
+**Unit**
+- Responses API payload contains `prompt.variables` (stage/phase).
+- Intent Router JSON contract validation.
+- Gating test: `*_WRITE` cannot reach EXECUTE without CONFIRM.
+
+**Integration/E2E**
+1) “Zaplanuj mój dzień” → DAILY_PLAN → PLAN → CONFIRM → EXECUTE.
+2) “Napisz maila do X” → EMAIL_WRITE → PLAN → CONFIRM → EXECUTE.
+
+**UI (pre-req)**
+- RTL tests for PromptInput: render + typing + submit enabled/disabled.
+- RTL tests for ModelSelector (via multimodal input): model change updates state.

--- a/backend/tool_call_handler/__init__.py
+++ b/backend/tool_call_handler/__init__.py
@@ -116,6 +116,112 @@ WP6_CONTEXT_PACK_TTL_SECONDS = int(os.environ.get("WP6_CONTEXT_PACK_TTL_SECONDS"
 WP6_DEEP_COOLDOWN_SECONDS = int(os.environ.get("WP6_DEEP_COOLDOWN_SECONDS", "600") or 600)
 OPENAI_CONTEXT_BUILDER_PROMPT_ID = os.environ.get("OPENAI_CONTEXT_BUILDER_PROMPT_ID", "")
 
+PA_INTENT_STAGES = (
+    "CALENDAR_QUERY",
+    "CALENDAR_WRITE",
+    "EMAIL_QUERY",
+    "EMAIL_WRITE",
+    "TASKS_MANAGE",
+    "DAILY_PLAN",
+    "NOTES_KB",
+    "DECISION_SUPPORT",
+    "DOC_ANALYSIS",
+    "REPORTING",
+    "TRAVEL_PLANNING",
+)
+PA_WRITE_STAGES = {"CALENDAR_WRITE", "EMAIL_WRITE", "TASKS_MANAGE"}
+
+
+def _pa_intent_router(user_text: str) -> Dict[str, Any]:
+    text = str(user_text or "").lower()
+    stage_scores = {stage: 0.0 for stage in PA_INTENT_STAGES}
+    evidence: list[str] = []
+
+    def _add(stage: str, keyword: str, weight: float = 1.0):
+        if keyword and keyword in text:
+            stage_scores[stage] += weight
+            evidence.append(f"{stage}:{keyword}")
+
+    email_terms = ["email", "mail", "inbox", "gmail", "outlook"]
+    email_write_terms = ["send", "draft", "write", "reply", "respond", "compose", "forward"]
+    email_query_terms = ["check", "read", "show", "find", "search", "unread", "latest", "last"]
+    calendar_terms = ["calendar", "meeting", "event", "appointment", "schedule"]
+    calendar_write_terms = ["schedule", "book", "reschedule", "move", "cancel", "create", "add", "invite"]
+    calendar_query_terms = ["when", "next", "upcoming", "availability", "free", "busy"]
+    tasks_terms = ["task", "todo", "to-do", "remind", "reminder", "follow up", "follow-up"]
+    plan_terms = ["plan my day", "daily plan", "agenda", "day plan", "schedule my day"]
+    notes_terms = ["note", "remember", "save", "store", "knowledge base", "kb", "notes"]
+    decision_terms = ["decide", "choose", "recommend", "compare", "pros and cons", "tradeoff", "advice"]
+    doc_terms = ["document", "pdf", "summarize", "analyze", "extract", "review", "report"]
+    reporting_terms = ["report", "metrics", "status update", "weekly summary", "kpi"]
+    travel_terms = ["travel", "trip", "flight", "hotel", "itinerary", "booking"]
+
+    for term in email_terms:
+        _add("EMAIL_QUERY", term, 0.5)
+        _add("EMAIL_WRITE", term, 0.5)
+    for term in email_write_terms:
+        _add("EMAIL_WRITE", term, 2.0)
+    for term in email_query_terms:
+        _add("EMAIL_QUERY", term, 1.5)
+
+    for term in calendar_terms:
+        _add("CALENDAR_QUERY", term, 0.5)
+        _add("CALENDAR_WRITE", term, 0.5)
+    for term in calendar_write_terms:
+        _add("CALENDAR_WRITE", term, 2.0)
+    for term in calendar_query_terms:
+        _add("CALENDAR_QUERY", term, 1.5)
+
+    for term in tasks_terms:
+        _add("TASKS_MANAGE", term, 1.5)
+    for term in plan_terms:
+        _add("DAILY_PLAN", term, 2.0)
+    for term in notes_terms:
+        _add("NOTES_KB", term, 1.5)
+    for term in decision_terms:
+        _add("DECISION_SUPPORT", term, 1.5)
+    for term in doc_terms:
+        _add("DOC_ANALYSIS", term, 1.5)
+    for term in reporting_terms:
+        _add("REPORTING", term, 1.5)
+    for term in travel_terms:
+        _add("TRAVEL_PLANNING", term, 1.5)
+
+    sorted_intents = sorted(stage_scores.items(), key=lambda item: item[1], reverse=True)
+    top_stage, top_score = sorted_intents[0]
+    second_score = sorted_intents[1][1] if len(sorted_intents) > 1 else 0.0
+    total_score = sum(stage_scores.values())
+
+    if total_score <= 0:
+        top_stage = "DECISION_SUPPORT"
+        top_score = 1.0
+        total_score = 1.0
+
+    top_intents = [
+        {"stage": stage, "p": round(score / total_score, 3)}
+        for stage, score in sorted_intents
+        if score > 0
+    ][:5]
+    if not top_intents:
+        top_intents = [{"stage": top_stage, "p": 1.0}]
+
+    need_clarification = top_score < 2.0 or (top_score - second_score) <= 1.0
+    clarify_questions = []
+    if need_clarification:
+        clarify_questions = [
+            "Czy chodzi o odczyt (QUERY), czy wykonanie akcji (WRITE)?",
+            "Podaj proszę dokładny zakres i oczekiwany rezultat.",
+        ]
+
+    return {
+        "top_intents": top_intents,
+        "recommended_stage": top_stage,
+        "recommended_phase": "DISCOVERY",
+        "need_clarification": need_clarification,
+        "clarify_questions": clarify_questions,
+        "evidence": evidence[:5],
+    }
+
 def _best_effort_debug(code: str, *, user_id: str = "", thread_id: str = "", error: Exception | None = None, **ctx: Any) -> None:
     logger = logging.getLogger()
     if not (DEBUG_TOOL_CALL_HANDLER or logger.isEnabledFor(logging.DEBUG)):
@@ -2294,6 +2400,9 @@ def run_responses(
     recent_turns: list[str] | None = None,
     run_id: str = "",
     trace_id: str = "",
+    stage: str = "",
+    phase: str = "",
+    intent_router: Dict[str, Any] | None = None,
 ) -> Tuple[str, list, Dict[str, Any], str]:
     """Responses API deterministic tool loop using a Prompt ID (dual-runtime mode)."""
     if not thread_id:
@@ -2317,8 +2426,11 @@ def run_responses(
     recent_turns_buffer: list[str] = list(recent_turns or [])
 
     for iteration in range(25):
+        prompt_payload: Dict[str, Any] = {"id": OPENAI_PROMPT_ID}
+        if stage or phase:
+            prompt_payload["variables"] = {"stage": stage, "phase": phase}
         create_kwargs: Dict[str, Any] = {
-            "prompt": {"id": OPENAI_PROMPT_ID},
+            "prompt": prompt_payload,
             "input": current_input,
             "tool_choice": "auto",
             "parallel_tool_calls": False,
@@ -2329,6 +2441,7 @@ def run_responses(
                 "user_id": str(user_id),
                 "thread_id": str(thread_id),
                 "runtime": "responses",
+                **({"stage": stage, "phase": phase} if (stage or phase) else {}),
                 **(
                     {"recent_user_turns": _wp6_recent_turns_metadata(recent_turns_buffer)}
                     if recent_turns_buffer
@@ -2450,7 +2563,14 @@ def run_responses(
             final_text = getattr(response, "output_text", None) or ""
             if not final_text:
                 final_text = "No response from assistant."
-            meta = {"responses_conversation_id": conversation_id, "responses_last_response_id": previous_response_id}
+            meta = {
+                "responses_conversation_id": conversation_id,
+                "responses_last_response_id": previous_response_id,
+                "stage": stage,
+                "phase": phase,
+            }
+            if intent_router:
+                meta["intent_router"] = intent_router
             # Persist only after reaching a "final" response to avoid saving a response id with pending tool calls.
             try:
                 if (not WP6_RESPONSES_STATELESS) and persist_handles and isinstance(handles, dict):
@@ -3707,6 +3827,30 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
                 wp6_meta["recent_user_turns_count"] = int(len(recent_turns or []))
                 wp6_meta["recent_user_turns_chars"] = int(sum(len(str(t or "")) for t in (recent_turns or [])))
 
+                requested_stage = str(body.get("stage") or "").strip().upper()
+                requested_phase = str(body.get("phase") or "").strip().upper()
+                intent_router = None
+                if not requested_stage or not requested_phase:
+                    intent_router = _pa_intent_router(user_message)
+                    if not requested_stage:
+                        requested_stage = str(intent_router.get("recommended_stage") or "").strip().upper()
+                    if not requested_phase:
+                        requested_phase = str(intent_router.get("recommended_phase") or "").strip().upper()
+                if not requested_stage:
+                    requested_stage = "DECISION_SUPPORT"
+                if not requested_phase:
+                    requested_phase = "DISCOVERY"
+                wp6_meta["pa_stage"] = requested_stage
+                wp6_meta["pa_phase"] = requested_phase
+                if intent_router:
+                    wp6_meta["pa_intent_router"] = intent_router
+                logging.info(
+                    "PA routing stage=%s phase=%s need_clarification=%s",
+                    requested_stage,
+                    requested_phase,
+                    bool(intent_router and intent_router.get("need_clarification")),
+                )
+
                 audit_id = uuid.uuid4().hex[:12] if WP6_FAST_AUDIT_ENABLED else ""
                 audit_in_path = ""
                 audit_out_path = ""
@@ -3913,6 +4057,9 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
                     recent_turns=recent_turns,
                     run_id=run_id,
                     trace_id=trace_id,
+                    stage=requested_stage,
+                    phase=requested_phase,
+                    intent_router=intent_router,
                 )
 
                 # Phase 2 (AUTO only): parse FAST response signal and optionally escalate to DEEP once.
@@ -3954,6 +4101,9 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
                                     recent_turns=recent_turns,
                                     run_id=run_id,
                                     trace_id=trace_id,
+                                    stage=requested_stage,
+                                    phase=requested_phase,
+                                    intent_router=intent_router,
                                 )
                                 deep_signal, deep_cleaned = _wp6_parse_need_deep_signal(deep_resp or "")
                                 wp6_meta["need_deep_signal_deep"] = deep_signal
@@ -4208,4 +4358,3 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
                 detach_file_handler(file_handler)
             except Exception:
                 logging.warning("Failed to detach file log handler")
-


### PR DESCRIPTION
### Motivation
- Introduce semantic intent routing for the Personal Assistant so the system can distinguish QUERY vs WRITE-style intents and apply action gating.
- Surface `stage`/`phase` to the OpenAI Responses runtime so prompts can react to assistant intent (mirroring CV-generator prompt variable patterns).
- Capture routing evidence and decisions for observability and to enable later logging/export for ML training and gating enforcement.

### Description
- Added PA intent definitions `PA_INTENT_STAGES` and `PA_WRITE_STAGES` and implemented a lightweight inline router function `_pa_intent_router(user_text)` that returns top intents, `recommended_stage`, `recommended_phase`, `need_clarification`, `clarify_questions`, and evidence.
- Extended `run_responses` signature to accept `stage`, `phase`, and `intent_router` and included `prompt.variables` (with `stage`/`phase`) in the Responses API `create` payload when available.
- Augmented Responses metadata to include `stage`, `phase` and optionally `intent_router` in the final `responses_meta` returned from `run_responses`.
- Wired routing into the main handler: determine `requested_stage`/`requested_phase` from request `body` or from the `_pa_intent_router` output, store values under `wp6_meta` (`pa_stage`, `pa_phase`, `pa_intent_router`), log routing decisions, and propagate `stage`/`phase`/`intent_router` into all `run_responses` calls (including DEEP escalation paths).

### Testing
- No automated tests were executed for this change.
- Changes were smoke-validated by static inspection and by ensuring the modified code paths compile in the repository (no runtime tests requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989a79834f8832186a9e3852476d6f5)